### PR TITLE
Update huawei map initialize method place

### DIFF
--- a/mapskit/src/main/java/com/trendyol/mapskit/maplibrary/HuaweiMapsOperations.kt
+++ b/mapskit/src/main/java/com/trendyol/mapskit/maplibrary/HuaweiMapsOperations.kt
@@ -34,8 +34,8 @@ class HuaweiMapsOperations(context: Context) :
     private var isLiteModeEnabled: Boolean? = null
 
     init {
-        mapView = MapView(context)
         MapsInitializer.initialize(context)
+        mapView = MapView(context)
     }
 
     override fun onMapReady(map: HuaweiMap) {


### PR DESCRIPTION
According to official Huawei documentation, we need to call MapsInitializer.initialize method before obtaining a map. It is already working properly with fragments but not with activities. It can cause possible bugs in the future and impact stability.
Reference: https://developer.huawei.com/consumer/en/doc/development/HMSCore-Guides/android-sdk-map-instance-creation-0000001062881706
